### PR TITLE
Fix empty heading check to ignore blank lines

### DIFF
--- a/org-xob.el
+++ b/org-xob.el
@@ -136,16 +136,17 @@ item. (credit https://emacs.stackexchange.com/a/26840)."
        (invisible-p (point-at-eol))))
 
 (defun org-xob-empty-entry-p ()
-  "Returns true if this entry is empty."
+  "Return non-nil if the current heading contains no text.
+Whitespace and blank lines are ignored."
   (when (org-at-heading-p)
-    (let (a b)
-      (save-excursion
-        (org-end-of-subtree)
-        (setq a (point)))
-      (save-excursion
-        (end-of-line)
-        (setq b (point)))
-      (= a b))))
+    (let ((heading-end (save-excursion
+                         (end-of-line)
+                         (point)))
+          (entry-end (save-excursion
+                       (outline-next-heading)
+                       (skip-chars-backward " \t\n")
+                       (point))))
+      (= heading-end entry-end))))
 
 ;;;; Commands
 ;;;;; Main Commands

--- a/tests/org-xob-empty-entry-test.el
+++ b/tests/org-xob-empty-entry-test.el
@@ -1,0 +1,33 @@
+;;; org-xob-empty-entry-test.el --- tests for org-xob-empty-entry-p -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'org)
+
+;; Load the library while stubbing out heavy dependencies.
+(let ((orig-require (symbol-function 'require)))
+  (cl-letf (((symbol-function 'require)
+             (lambda (feature &optional filename noerror)
+               (if (memq feature '(org org-id))
+                   (funcall orig-require feature filename noerror)
+                 t))))
+    (load-file (expand-file-name "../org-xob.el" (file-name-directory load-file-name)))))
+
+(ert-deftest org-xob-empty-entry-p-empty ()
+  "Detect empty headings even when blank lines are present."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Foo\n\n* Bar")
+    (goto-char (point-min))
+    (should (org-xob-empty-entry-p))))
+
+(ert-deftest org-xob-empty-entry-p-non-empty ()
+  "Return nil when heading contains text."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Foo\nContent\n* Bar")
+    (goto-char (point-min))
+    (should-not (org-xob-empty-entry-p))))
+
+(provide 'org-xob-empty-entry-test)
+
+;;; org-xob-empty-entry-test.el ends here


### PR DESCRIPTION
## Summary
- detect empty Org headings even when trailing blank lines are present
- add regression tests for `org-xob-empty-entry-p`

## Testing
- `emacs --batch -l tests/org-xob-empty-entry-test.el -f ert-run-tests-batch-and-exit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980e0fb67c832db4138423ff134587