### PR TITLE
Fix lowercase id link hook handling

### DIFF
--- a/org-xob-backend.el
+++ b/org-xob-backend.el
@@ -814,7 +814,7 @@ as a capture hook function."
 Only acts on ID links that are registered xob nodes in the hash table."
   (let ((link (org-element-context))
         ID title)
-    (when (equal "ID" (org-element-property :type link))
+    (when (equal "id" (org-element-property :type link))
       (setq ID (org-element-property :path link))
       (setq title (gethash ID org-xob--id-title))
       ;; Only act if this ID is actually a registered xob node

--- a/tests/test-link-hook.el
+++ b/tests/test-link-hook.el
@@ -1,0 +1,31 @@
+;;; test-link-hook.el --- Tests for org-xob link hook -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Tests for following id: links through the org-xob hook.
+
+;;; Code:
+
+(require 'ert)
+(require 'org)
+(require 'cl-lib)
+(require 'org-xob-backend)
+
+(ert-deftest org-xob-link-hook-opens-registered-id-link ()
+  "Following a registered id: link opens the matching XOB edit node."
+  (let* ((node-id "12345678-1234-1234-1234-123456789abc")
+         (node-title "Linked XOB Node")
+         (org-xob--id-title (make-hash-table :test 'equal))
+         opened)
+    (puthash node-id node-title org-xob--id-title)
+    (with-temp-buffer
+      (org-mode)
+      (insert (format "[[id:%s][%s]]" node-id node-title))
+      (goto-char (point-min))
+      (cl-letf (((symbol-function 'org-xob--edit-node)
+                 (lambda (id title)
+                   (setq opened (list id title)))))
+        (should (org-xob--link-hook-fn))
+        (should (equal opened (list node-id node-title)))))))
+
+(provide 'test-link-hook)
+;;; test-link-hook.el ends here


### PR DESCRIPTION
### Motivation

- Org uses lowercase link types (e.g. `id`), and the link hook was comparing against uppercase `"ID"`, causing `id:` links to be ignored by the XOB follow-link hook.

### Description

- Update `org-xob--link-hook-fn` in `org-xob-backend.el` to compare `(org-element-property :type link)` against lowercase `"id"` instead of `"ID"`.
- Add `tests/test-link-hook.el`, an ERT test that constructs an `id:` link, registers the node ID/title in `org-xob--id-title`, stubs `org-xob--edit-node`, and asserts the hook resolves the node ID and invokes the edit-opening path.
- Run a repository search for `org-element-property :type` usages to ensure link-type comparisons are consistent.

### Testing

- Ran repository searches (`rg`) for `org-element-property :type` and related patterns to verify occurrences and confirm the change; the searches completed successfully.
- Attempted to run the new ERT test with `emacs --batch -L . -L tests -l tests/test-link-hook.el -f ert-run-tests-batch-and-exit`, but `emacs` is not installed in the execution environment so the ERT test was not executed.
- The new test file `tests/test-link-hook.el` is present and designed to pass when run in an environment with Emacs available and the package load-path configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e7ee5c3b0832d91c91bf4a5a974aa)