### PR TITLE
Handle mixed Org heading clips in smart paste

### DIFF
--- a/org-xob-backend.el
+++ b/org-xob-backend.el
@@ -387,22 +387,51 @@ changed since opening this copy."
   "paste clip at the end of the headings top section.
 Point needs to be on the heading."
   (org-with-wide-buffer
-   (if (org-goto-first-child)
-       (progn
-         (newline 2)
-         (forward-line -1))
-     (org-end-of-subtree)
-     (newline))
-   (org-xob--smart-paste clip)))
+   (let ((destination-level (org-current-level)))
+     (if (org-goto-first-child)
+         (progn
+           (newline 2)
+           (forward-line -1))
+       (org-end-of-subtree)
+       (newline))
+     (org-xob--smart-paste clip destination-level))))
 
-(defun org-xob--smart-paste (&optional clip)
+(defun org-xob--normalize-clip-headings (clip destination-level)
+  "Return CLIP with its minimum heading level below DESTINATION-LEVEL.
+CLIP is normalized in an Org temporary buffer.  Leading non-heading text is
+left unchanged while every heading in CLIP is shifted by the same amount, so
+relative nesting is preserved."
+  (with-temp-buffer
+    (org-mode)
+    (insert clip)
+    (goto-char (point-min))
+    (let (minimum-level)
+      (while (re-search-forward "^\\(\\*+\\) " nil t)
+        (let ((level (length (match-string 1))))
+          (setq minimum-level (if minimum-level
+                                  (min minimum-level level)
+                                level))))
+      (when minimum-level
+        (let ((shift (- (1+ destination-level) minimum-level)))
+          (goto-char (point-min))
+          (while (re-search-forward "^\\(\\*+\\) " nil t)
+            (replace-match
+             (make-string (+ (length (match-string 1)) shift) ?*)
+             t t nil 1)))))
+    (buffer-string)))
+
+(defun org-xob--smart-paste (&optional clip destination-level)
   "If the paste is an org subtree, then properly adjust levels for the current heading.
 Otherwise just yank. If heading is a xob node, then update modified time property."
   (save-excursion
     (if clip
         (if (org-kill-is-subtree-p clip)
             (org-paste-subtree nil clip nil nil)
-          (insert clip))
+          (if (string-match-p "^\\*+ " clip)
+              (insert (org-xob--normalize-clip-headings
+                       clip
+                       (or destination-level (org-current-level) 0)))
+            (insert clip)))
       (if (org-kill-is-subtree-p)
           (org-paste-subtree nil clip t t)
         (yank))))

--- a/tests/test-smart-paste.el
+++ b/tests/test-smart-paste.el
@@ -1,0 +1,75 @@
+;;; test-smart-paste.el --- Tests for smart top-section paste -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Regression tests for pasting mixed Org clips into an XOB node top section.
+
+;;; Code:
+
+(require 'ert)
+(require 'org)
+(require 'cl-lib)
+(require 'org-xob-backend)
+
+(defmacro org-xob-test--with-silent-modified-time (&rest body)
+  "Run BODY without requiring an XOB node for modified-time updates."
+  `(cl-letf (((symbol-function 'org-xob--update-modified-time) #'ignore))
+     ,@body))
+
+(defun org-xob-test--paste-top-section (initial clip)
+  "Paste CLIP at the top section of INITIAL's first heading.
+Return the resulting buffer text."
+  (with-temp-buffer
+    (org-mode)
+    (insert initial)
+    (goto-char (point-min))
+    (org-xob-test--with-silent-modified-time
+     (org-xob--paste-top-section clip))
+    (buffer-string)))
+
+(ert-deftest org-xob-smart-paste-mixed-headings-destination-with-no-children ()
+  "A mixed clip's minimum heading becomes a child of a childless destination."
+  (should
+   (equal
+    (org-xob-test--paste-top-section
+     "* Destination\nTop section.\n"
+     "Intro text.\n* Imported\nBody.\n")
+    "* Destination\nTop section.\nIntro text.\n** Imported\nBody.\n")))
+
+(ert-deftest org-xob-smart-paste-mixed-headings-destination-with-existing-children ()
+  "A mixed clip is inserted before existing children in the destination top section."
+  (should
+   (equal
+    (org-xob-test--paste-top-section
+     "* Destination\nTop section.\n** Existing child\nChild body.\n"
+     "Intro text.\n* Imported\nBody.\n")
+    "* Destination\nTop section.\nIntro text.\n** Imported\nBody.\n\n** Existing child\nChild body.\n")))
+
+(ert-deftest org-xob-smart-paste-mixed-headings-preserves-leading-text ()
+  "Leading non-heading text remains top-section content before normalized headings."
+  (should
+   (equal
+    (org-xob-test--paste-top-section
+     "* Destination\n"
+     "Leading paragraph.\n- list item\n** Imported\nBody.\n")
+    "* Destination\nLeading paragraph.\n- list item\n** Imported\nBody.\n")))
+
+(ert-deftest org-xob-smart-paste-mixed-headings-preserves-relative-nesting ()
+  "Nested headings in a mixed clip retain their relative depth."
+  (should
+   (equal
+    (org-xob-test--paste-top-section
+     "* Destination\n"
+     "Intro text.\n** Imported\n*** Nested\nNested body.\n")
+    "* Destination\nIntro text.\n** Imported\n*** Nested\nNested body.\n")))
+
+(ert-deftest org-xob-smart-paste-no-heading-clip-inserts-plain-text ()
+  "A clip with no headings continues to insert without normalization."
+  (should
+   (equal
+    (org-xob-test--paste-top-section
+     "* Destination\n"
+     "Plain text only.\n")
+    "* Destination\nPlain text only.\n")))
+
+(provide 'test-smart-paste)
+;;; test-smart-paste.el ends here


### PR DESCRIPTION
### Motivation
- Allow pastes that are not full Org subtrees but do contain one or more headings to be normalized so they insert at the correct depth under the destination heading.
- Preserve any leading non-heading text as top-section content and maintain relative nesting among imported headings.
- Ensure existing behavior for true subtrees and plain text clips is unchanged.

### Description
- Capture the destination heading level with `(org-current-level)` in `org-xob--paste-top-section` and pass it into `org-xob--smart-paste`.
- Add `org-xob--normalize-clip-headings` which inserts the clip into a temporary `org-mode` buffer, finds the minimum heading level, and shifts all headings so the minimum becomes one level deeper than the destination while preserving relative nesting and leading non-heading text.
- Update `org-xob--smart-paste` to detect non-subtree clips that contain headings via the regexp `^\*+ ` and normalize them before insertion, while leaving no-heading clips as plain `(insert clip)` and keeping subtree clips using `org-paste-subtree`.
- Add regression tests in `tests/test-smart-paste.el` covering destination nodes with no children, destination nodes with existing children, regions with leading text before a heading, nested subtrees, and plain text clips.

### Testing
- Ran `git diff --check` which returned clean (no whitespace errors).
- Added ERT tests in `tests/test-smart-paste.el` that exercise the new behavior for mixed-heading clips and plain clips but they could not be executed in this environment because `emacs` is not installed, so automated ERT execution was blocked.
- Manual test cases are encoded in the new ERT file for the scenarios: childless destination, destination with existing children, leading text before heading, nested subtree, and no-heading clip.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e828fc6d8832db47af93092b4b7d6)